### PR TITLE
fix segmentation fault error

### DIFF
--- a/BackEndProxy.Tests/BackendTest.cs
+++ b/BackEndProxy.Tests/BackendTest.cs
@@ -72,11 +72,11 @@ namespace BackEndProxy.Tests
 
             WebSocketWrapper wsw = WebSocketWrapper.Create(url);
 
-            Task task = new Task(() =>
+            Task task = new Task(async () =>
             {
                 wsw.Connect();
                 while (!endTest || !playbackReader.IsClosed) { }
-                wsw.Disconnect();
+                await wsw.Disconnect();
             });
 
             wsw.OnMessage(async (msg, sock) =>
@@ -143,11 +143,11 @@ namespace BackEndProxy.Tests
             string url = $"ws://{proxyHost}:{proxyPort}";
             WebSocketWrapper wsw = WebSocketWrapper.Create(url);
 
-            Task task = new Task(() =>
+            Task task = new Task(async () =>
             {
                 wsw.Connect();
                 while (!playbackReader.IsClosed) { }
-                wsw.Disconnect();
+                await wsw.Disconnect();
             });
 
             wsw.OnMessage(async (msg, sock) =>

--- a/BackendProxy2ASR/CommASR.cs
+++ b/BackendProxy2ASR/CommASR.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Text;
-
+using System.Threading.Tasks;
 using Fleck;
 using database_and_log;
 using Serilog;
@@ -27,8 +27,6 @@ namespace BackendProxy2ASR
 
         private ILogger _logger = LogHelper.GetLogger<CommASR>();
 
-        public WebSocketState ASRWsState;
-
         protected CommASR(String asrIP, int asrPort, int sampleRate, Dictionary<String, IWebSocketConnection> sessionID2sock, 
             Dictionary<String, SessionHelper> sessionID2helper, DatabaseHelper databaseHelper)
         {
@@ -41,8 +39,6 @@ namespace BackendProxy2ASR
 
             m_sessionID2wsWrap = new Dictionary<String, WebSocketWrapper>();
             m_wsWrap2sessionID = new Dictionary<WebSocketWrapper, String>();
-
-            ASRWsState = WebSocketState.None;
 
         }
 
@@ -79,7 +75,6 @@ namespace BackendProxy2ASR
                     _logger.Information("Connected to ASR Engine: sessionID = " + sessionID);
                     m_sessionID2wsWrap[sessionID] = sock;
                     m_wsWrap2sessionID[sock] = sessionID;
-                    ASRWsState = WebSocketState.Open;
                     SendStartStream(sessionID);
                 }
             );
@@ -96,11 +91,12 @@ namespace BackendProxy2ASR
 
             wsw.OnDisconnect((sock) =>
                 {
-                    SendEndStream(sessionID);
-                    m_sessionID2wsWrap.Remove(sessionID);
-                    m_wsWrap2sessionID.Remove(sock);
-                    ASRWsState = WebSocketState.Closed;
-                    _logger.Information("Disconnected from ASR Engine: sessionID = " + sessionID);
+                    if (m_sessionID2wsWrap.ContainsKey(sessionID))
+                    {
+                        m_sessionID2wsWrap.Remove(sessionID);
+                        m_wsWrap2sessionID.Remove(sock);
+                        _logger.Information("Disconnected from ASR Engine: sessionID = " + sessionID);
+                    }
                 }
             );
 
@@ -118,13 +114,13 @@ namespace BackendProxy2ASR
         //----------------------------------------------------------------------------------------->
         // disconnect from ASR when client disconnect
         //----------------------------------------------------------------------------------------->
-        public void DisconnectASR(String sessionID)
+        public async void DisconnectASR(String sessionID)
         {
-            if (m_sessionID2wsWrap.ContainsKey(sessionID) == true)
+            if (m_sessionID2wsWrap.ContainsKey(sessionID))
             {
                 var wsw = m_sessionID2wsWrap[sessionID];
-                wsw.Disconnect();
-                _logger.Information("DisconnectASR: sessionID = " + sessionID);
+                await SendEndStream(sessionID);
+                await wsw.Disconnect();
             }
             else
             {
@@ -135,7 +131,7 @@ namespace BackendProxy2ASR
         //----------------------------------------------------------------------------------------->
         // send binary data to ASR engine
         //----------------------------------------------------------------------------------------->
-        public void SendStartStream(String sessionID)
+        public async void SendStartStream(String sessionID)
         {
             if (m_sessionID2wsWrap.ContainsKey(sessionID) == true)
             {
@@ -144,7 +140,7 @@ namespace BackendProxy2ASR
                 //----------------------------------------------->
                 byte[] start = new byte[1];
                 start[0] = 0;
-                SendBinaryData(sessionID, start);
+                await SendBinaryData(sessionID, start);
                 //m_sessionID2wsWrap[sessionID].SendBytes(start);
 
                 _logger.Information("start pkt sent to start stream: sessionID = " + sessionID);
@@ -158,7 +154,7 @@ namespace BackendProxy2ASR
         //----------------------------------------------------------------------------------------->
         // send binary data to ASR engine
         //----------------------------------------------------------------------------------------->
-        public void SendEndStream(String sessionID)
+        public async Task SendEndStream(String sessionID)
         {
             if (m_sessionID2wsWrap.ContainsKey(sessionID) == true)
             {
@@ -167,7 +163,7 @@ namespace BackendProxy2ASR
                 //----------------------------------------------->
                 byte[] end = new byte[1];
                 end[0] = 1;
-                SendBinaryData(sessionID, end);
+                await SendBinaryData(sessionID, end);
                 //m_sessionID2wsWrap[sessionID].SendBytes(end);
 
                 _logger.Information("end pkt sent to end stream: sessionID = " + sessionID);
@@ -181,7 +177,7 @@ namespace BackendProxy2ASR
         //----------------------------------------------------------------------------------------->
         // send binary data to ASR engine
         //----------------------------------------------------------------------------------------->
-        public void SendBinaryData(String sessionID, byte[] data)
+        public async Task SendBinaryData(String sessionID, byte[] data)
         {
             if (m_sessionID2wsWrap.ContainsKey(sessionID) == true)
             {
@@ -195,8 +191,7 @@ namespace BackendProxy2ASR
                     {
                         _logger.Information("ASR state: " + wsw.GetWebSocketState().ToString());
                         _logger.Error("ASR Websocket is not open.");
-                        ASRWsState = wsw.GetWebSocketState();
-                        wsw.Disconnect();
+                        await wsw.Disconnect();
                     }
                     else
                     {

--- a/BackendProxy2ASR/CommASR.cs
+++ b/BackendProxy2ASR/CommASR.cs
@@ -114,7 +114,7 @@ namespace BackendProxy2ASR
         //----------------------------------------------------------------------------------------->
         // disconnect from ASR when client disconnect
         //----------------------------------------------------------------------------------------->
-        public async void DisconnectASR(String sessionID)
+        public async Task DisconnectASR(String sessionID)
         {
             if (m_sessionID2wsWrap.ContainsKey(sessionID))
             {
@@ -195,7 +195,7 @@ namespace BackendProxy2ASR
                     }
                     else
                     {
-                        wsw.SendBytes(data);
+                        await wsw.SendBytes(data);
                     }
                     
                 }

--- a/BackendProxy2ASR/ProxyServer.cs
+++ b/BackendProxy2ASR/ProxyServer.cs
@@ -97,9 +97,9 @@ namespace BackendProxy2ASR
                         OnConnect(socket);
                     };
 
-                    socket.OnClose = () =>
+                    socket.OnClose = async () =>
                     {
-                        OnDisconnect(socket);
+                        await OnDisconnect(socket);
                     };
 
                     socket.OnMessage = message =>
@@ -198,7 +198,7 @@ namespace BackendProxy2ASR
         //--------------------------------------------------------------------->
         // Handle websocket disconnect
         //--------------------------------------------------------------------->
-        private void OnDisconnect(IWebSocketConnection sock)
+        private async Task OnDisconnect(IWebSocketConnection sock)
         {
             // Disconnect from ASR engine
             if (m_sock2sessionID.ContainsKey(sock))
@@ -209,7 +209,7 @@ namespace BackendProxy2ASR
                 m_sessonId2PingCancellationTokenSource[session_id].Cancel();
                 m_sessonId2PingCancellationTokenSource.Remove(session_id);
 
-                m_commASR.DisconnectASR(session_id);
+                await m_commASR.DisconnectASR(session_id);
                 m_sessionID2Helper.Remove(session_id);
                 m_sessionID2sock.Remove(session_id);
                 m_sock2sessionID.Remove(sock);

--- a/BackendProxy2ASR/WebSocketWrapper.cs
+++ b/BackendProxy2ASR/WebSocketWrapper.cs
@@ -72,15 +72,11 @@ namespace BackendProxy2ASR
         //----------------------------------------------------------------------------------------->
         // Disconnects from WebSocket server.
         //----------------------------------------------------------------------------------------->
-        public WebSocketWrapper Disconnect()
+        public async Task Disconnect()
         {
-            //if ((_ws.State == WebSocketState.Open))
-            //{
-                CallOnDisconnected();
-                _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, _cancellationToken);
-                //CallOnDisconnected();
-            //}
-            return this;
+            CallOnDisconnected();
+            await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, _cancellationToken);
+            _ws.Dispose();
         }
 
         //----------------------------------------------------------------------------------------->

--- a/BackendProxy2ASR/WebSocketWrapper.cs
+++ b/BackendProxy2ASR/WebSocketWrapper.cs
@@ -76,7 +76,6 @@ namespace BackendProxy2ASR
         {
             CallOnDisconnected();
             await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, _cancellationToken);
-            _ws.Dispose();
         }
 
         //----------------------------------------------------------------------------------------->
@@ -93,11 +92,11 @@ namespace BackendProxy2ASR
         // send binary data to WebSocket server
         //      public interface
         //----------------------------------------------------------------------------------------->
-        public void SendBytes(byte[] bytes)
+        public async Task SendBytes(byte[] bytes)
         {
             try
             {
-                SendBytesAsync(bytes);
+                await SendBytesAsync(bytes);
             }
             catch (Exception e)
             {
@@ -169,7 +168,7 @@ namespace BackendProxy2ASR
         // send binary data to WebSocket server
         //      the actual implementation for the public interface
         //----------------------------------------------------------------------------------------->
-        private async void SendBytesAsync(byte[] bytes)
+        private async Task SendBytesAsync(byte[] bytes)
         {
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(FatalExceptionHandler);
             try


### PR DESCRIPTION
# Change Log

## CommASR

- replace WebSocketState ASRWsState in CommASR with try catch in ProxyServer
- move SendEndStream(sessionID); from ondisconnect callback to DisconnectASR
- update SendEndStream, SendStartStream, SendBinaryData and DisconnectASRto become async functions

## ProxyServer

- Implement cancellation token in send ping task
- update OnBinaryData and OnDisconnect to become async
- replace WebSocketState ASRWsState in CommASR with try catch in ProxyServer
- change sock.OnClose() to sock.Close in startping

## WebSocketWrapper

- update Disconnect() and SendBytes function to async
- await _ws.CloseAsync and add _ws.Dispose();